### PR TITLE
add status and complete resource number

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	myresourceclientset "github.com/xiaoheigou/mycrd/pkg/client/clientset/versioned"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -13,11 +14,12 @@ import (
 )
 
 type Controller struct {
-	logger    *log.Entry
-	clientset kubernetes.Interface
-	queue     workqueue.RateLimitingInterface
-	informer  cache.SharedIndexInformer
-	handler   Handler
+	logger           *log.Entry
+	clientset        kubernetes.Interface
+	myresourceClient *myresourceclientset.Clientset
+	queue            workqueue.RateLimitingInterface
+	informer         cache.SharedIndexInformer
+	handler          Handler
 }
 
 func (c *Controller) Run(stopCh <-chan struct{}) {
@@ -110,8 +112,8 @@ func (c *Controller) processNextItem() bool {
 		c.handler.ObjectDeleted(item)
 		c.queue.Forget(key)
 	} else {
-		c.logger.Infof("Controller.processNextItem: object created detected: %s[resource number:pod:]", keyRaw)
-		c.handler.ObjectCreated(item)
+		c.logger.Infof("Controller.processNextItem: object created detected: %s", keyRaw)
+		c.handler.ObjectCreated(item, c.clientset, c.myresourceClient)
 		c.queue.Forget(key)
 	}
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
-func getKubernetesClient() (kubernetes.Interface, myresourceclientset.Interface) {
+func getKubernetesClient() (kubernetes.Interface, *myresourceclientset.Clientset) {
 	// construct the path to resolve to `~/.kube/config`
 	// kubeConfigPath := os.Getenv("HOME") + "/.kube/config"
 	kubeConfigPath := "/etc/kubernetes/kubectl.kubeconfig"
@@ -93,11 +93,12 @@ func main() {
 
 	// ## 2.controller
 	controller := Controller{
-		logger:    log.NewEntry(log.New()),
-		clientset: client,
-		informer:  informer,
-		queue:     queue,
-		handler:   &TestHandler{},
+		logger:           log.NewEntry(log.New()),
+		clientset:        client,
+		myresourceClient: myresourceClient,
+		informer:         informer,
+		queue:            queue,
+		handler:          &TestHandler{},
 	}
 	// use a channel to synchronize the finalization for a graceful shutdown
 	stopCh := make(chan struct{})

--- a/pkg/apis/myresource/v1/types.go
+++ b/pkg/apis/myresource/v1/types.go
@@ -22,7 +22,8 @@ type MyResource struct {
 	meta_v1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec is the custom resource spec
-	Spec MyResourceSpec `json:"spec"`
+	Spec   MyResourceSpec   `json:"spec"`
+	Status MyResourceStatus `json:"status,omitempty"`
 }
 
 // MyResourceSpec is the spec for a MyResource resource
@@ -42,4 +43,9 @@ type MyResourceList struct {
 	meta_v1.ListMeta `json:"metadata"`
 
 	Items []MyResource `json:"items"`
+}
+
+// MyResourceStatus is a map of resource number
+type MyResourceStatus struct {
+	ResourceNumber map[string]int
 }


### PR DESCRIPTION
**count the pods,nodes,mycrd source number .
below show $kubectl get MyResource example-myresource -o yaml**

```
[root@c421v96]:~/mycrd/example# kubectl get MyResource example-myresource -o yaml
apiVersion: trstringer.com/v1
kind: MyResource
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"trstringer.com/v1","kind":"MyResource","metadata":{"annotations":{},"name":"example-myresource","namespace":"default"},"spec":{"message":"hello world","someValue":13}}
  clusterName: ""
  creationTimestamp: 2018-05-17T05:45:01Z
  generation: 1
  name: example-myresource
  namespace: default
  resourceVersion: "2230309"
  selfLink: /apis/trstringer.com/v1/namespaces/default/myresources/example-myresource
  uid: 70f34fd0-5995-11e8-bc98-5254003eab11
spec:
  message: hello world
  someValue: 13
status:
  ResourceNumber:
    myresource: 1
    nodes: 4
    pod: 112
```